### PR TITLE
Add support for downloading through a proxy

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -313,6 +313,7 @@ func copyFromURL(dstFile, srcURL string) (err error) {
 		Transport: &userAgentTransport{&http.Transport{
 			// It's already compressed. Prefer accurate ContentLength.
 			// (Not that GCS would try to compress it, though)
+			Proxy:              http.ProxyFromEnvironment,
 			DisableCompression: true,
 			DisableKeepAlives:  true,
 		}},


### PR DESCRIPTION
I work behind a corporate proxy, which isn't supported by the build tool, so I am unable to test the RCs of the next version of Go.

This adds support for reading proxy setup from the standard environment variables.