### PR TITLE
env/openbsd-amd64: use version 6.3, make disklabel readable

### DIFF
--- a/env/openbsd-amd64/README
+++ b/env/openbsd-amd64/README
@@ -1,7 +1,8 @@
 make.bash creates a Google Compute Engine VM image to run the Go
 OpenBSD builder, booting up to run the buildlet.
 
-make.bash should be run on a Linux box with qemu.
+make.bash should be run on a Linux box with expect and qemu.
+Debian packages: expect qemu-utils qemu-system-x86.
 
 After it completes, it creates a file openbsd-amd64-gce.tar.gz
 

--- a/env/openbsd-amd64/make.bash
+++ b/env/openbsd-amd64/make.bash
@@ -144,6 +144,7 @@ send "s\n"
 expect timeout { exit 1 } "# "
 send "mount /dev/cd0c /mnt\n"
 send "cp /mnt/auto_install.conf /mnt/disklabel.template /\n"
+send "chmod a+r /disklabel.template\n"
 send "umount /mnt\n"
 send "exit\n"
 

--- a/env/openbsd-amd64/make.bash
+++ b/env/openbsd-amd64/make.bash
@@ -23,7 +23,7 @@ readonly ISO="install${RELNO}-${ARCH}.iso"
 readonly ISO_PATCHED="install${RELNO}-${ARCH}-patched.iso"
 
 if [[ ! -f "${ISO}" ]]; then
-  curl -o "${ISO}" "http://${MIRROR}/pub/OpenBSD/${VERSION}/${ARCH}/install${RELNO}.iso"
+  curl -o "${ISO}" "https://${MIRROR}/pub/OpenBSD/${VERSION}/${ARCH}/install${RELNO}.iso"
 fi
 
 function cleanup() {

--- a/env/openbsd-amd64/make.bash
+++ b/env/openbsd-amd64/make.bash
@@ -32,7 +32,7 @@ function cleanup() {
 	rm -f boot.conf
 	rm -f disk.raw
 	rm -f disklabel.template
-	rm -f etc/rc.local
+	rm -f etc/{installurl,rc.local}
 	rm -f install.site
 	rm -f random.seed
 	rm -f site${RELNO}.tgz
@@ -48,12 +48,15 @@ trap cleanup EXIT INT
 mkdir -p etc
 cat >install.site <<EOF
 #!/bin/sh
-env PKG_PATH=http://${MIRROR}/pub/OpenBSD/${VERSION}/packages/${ARCH} \
-  pkg_add -iv bash curl git
+syspatch
+pkg_add -iv bash curl git
 
 echo 'set tty com0' > boot.conf
 EOF
 
+cat >etc/installurl <<EOF
+https://${MIRROR}/pub/OpenBSD
+EOF
 cat >etc/rc.local <<EOF
 (
   set -x
@@ -80,7 +83,7 @@ cat >etc/rc.local <<EOF
 )
 EOF
 chmod +x install.site
-tar -zcvf site${RELNO}.tgz install.site etc/rc.local
+tar -zcvf site${RELNO}.tgz install.site etc/{installurl,rc.local}
 
 # Autoinstall script.
 cat >auto_install.conf <<EOF

--- a/env/openbsd-amd64/make.bash
+++ b/env/openbsd-amd64/make.bash
@@ -8,7 +8,7 @@
 set -e
 set -u
 
-readonly VERSION="6.2"
+readonly VERSION="6.3"
 readonly RELNO="${VERSION/./}"
 
 readonly ARCH="${ARCH:-amd64}"


### PR DESCRIPTION
Updates golang/go#26833

Restrictive root umask prevented ftp running as unprivileged user from reading disklabel file.