### PR TITLE
gerrit: add FileInfo status constants

### DIFF
--- a/gerrit/gerrit.go
+++ b/gerrit/gerrit.go
@@ -318,6 +318,15 @@ func (gpi *GitPersonInfo) Equal(v *GitPersonInfo) bool {
 		gpi.TZOffset == v.TZOffset
 }
 
+// Possible values for the FileInfo Status field.
+const (
+	FileInfoAdded     = "A"
+	FileInfoDeleted   = "D"
+	FileInfoRenamed   = "R"
+	FileInfoCopied    = "C"
+	FileInfoRewritten = "W"
+)
+
 type FileInfo struct {
 	Status        string `json:"status"`
 	Binary        bool   `json:"binary"`


### PR DESCRIPTION
Makes it easier for users of the ListFiles() API to evaluate Status in
FileInfo objects.