### PR TITLE
cmd/gopherbot: relaxed matching rule for the documentation label

### DIFF
--- a/cmd/gopherbot/gopherbot.go
+++ b/cmd/gopherbot/gopherbot.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -1988,8 +1989,11 @@ func isDocumentationTitle(t string) bool {
 	if strings.Contains(t, "godoc:") { // in x/tools, or the dozen places people file it as
 		return false
 	}
-	return strings.Contains(t, "documentation") ||
-		strings.Contains(t, "docs ")
+	if strings.Contains(t, "docs ") {
+		return true
+	}
+	return strings.Contains(t, "document") &&
+		regexp.MustCompile(`\bdocument\b`).MatchString(t)
 }
 
 func isGoplsTitle(t string) bool {

--- a/cmd/gopherbot/gopherbot.go
+++ b/cmd/gopherbot/gopherbot.go
@@ -1988,7 +1988,7 @@ func isDocumentationTitle(t string) bool {
 	if strings.Contains(t, "godoc:") { // in x/tools, or the dozen places people file it as
 		return false
 	}
-	return strings.Contains(t, "document") ||
+	return strings.Contains(t, "documentation") ||
 		strings.Contains(t, "docs ")
 }
 


### PR DESCRIPTION
Documentation word is more specific than the document word to match issues related to Documentation.

Fixes golang/go#31153