### PR TITLE
dashboard: rename builder dragonfly-amd64-5_6 to dragonfly-amd64-5_8

### DIFF
--- a/dashboard/builders.go
+++ b/dashboard/builders.go
@@ -362,7 +362,7 @@ var Hosts = map[string]*HostConfig{
 		env:         []string{"GOROOT_BOOTSTRAP=/usr/pkg/go112"},
 		OwnerGithub: "bsiegert",
 	},
-	"host-dragonfly-amd64-5_6": &HostConfig{
+	"host-dragonfly-amd64-5_8": &HostConfig{
 		IsReverse:   true,
 		ExpectNum:   1,
 		Notes:       "DragonFly BSD release version, run by DragonFly team",
@@ -2315,9 +2315,9 @@ func init() {
 		},
 	})
 	addBuilder(BuildConfig{
-		Name:              "dragonfly-amd64-5_6",
-		HostType:          "host-dragonfly-amd64-5_6",
-		Notes:             "DragonFly BSD 5.6 release",
+		Name:              "dragonfly-amd64-5_8",
+		HostType:          "host-dragonfly-amd64-5_8",
+		Notes:             "DragonFly BSD 5.8 release",
 		shouldRunDistTest: noTestDirAndNoReboot,
 		SkipSnapshot:      true,
 	})

--- a/dashboard/builders_test.go
+++ b/dashboard/builders_test.go
@@ -556,9 +556,9 @@ func TestBuilderConfig(t *testing.T) {
 		{b("dragonfly-amd64", "net"), onlyPost},
 		{b("dragonfly-amd64@go1.13", "net"), none}, // Dragonfly ABI changes only supported by Go 1.14+
 		{b("dragonfly-amd64@go1.13", "go"), none},  // Dragonfly ABI changes only supported by Go 1.14+
-		{b("dragonfly-amd64-5_6", "go"), onlyPost},
-		{b("dragonfly-amd64-5_6", "net"), onlyPost},
-		{b("dragonfly-amd64-5_6@go1.13", "net"), onlyPost},
+		{b("dragonfly-amd64-5_8", "go"), onlyPost},
+		{b("dragonfly-amd64-5_8", "net"), onlyPost},
+		{b("dragonfly-amd64-5_8@go1.13", "net"), onlyPost},
 
 		{b("linux-amd64-staticlockranking", "go"), onlyPost},
 		{b("linux-amd64-staticlockranking@go1.15", "go"), onlyPost},


### PR DESCRIPTION
* DragonFly BSD 5.8 was released on March 3rd, 2020. This is the next release after 5.6.
* Gobuilder VM has been upgraded to 5.8 and the scripts adjusted.