### PR TITLE
cmd/release: remember INSTALLDIR on upgrade

### DIFF
--- a/cmd/release/releaselet.go
+++ b/cmd/release/releaselet.go
@@ -403,6 +403,10 @@ var windowsData = map[string]string{
 <Property Id="EXISTING_GOLANG_INSTALLED">
   <RegistrySearch Id="installed" Type="raw" Root="HKCU" Key="Software\GoProgrammingLanguage" Name="installed" />
 </Property>
+<Property Id="INSTALLDIR">
+  <RegistrySearch Id="savedInstallDir" Type="raw" Root="HKCU" Key="Software\GoProgrammingLanguage" Name="installLocation" />
+</Property>
+
 <Media Id='1' Cabinet="go.cab" EmbedCab="yes" CompressionLevel="high" />
 <Condition Message="Windows 7 (with Service Pack 1) or greater required.">
     ((VersionNT > 601) OR (VersionNT = 601 AND ServicePackLevel >= 1))


### PR DESCRIPTION
When Go is upgraded on Windows, the previous installation location is
not reused.

Installation directory is already stored in registry so half of the work
is already done. The added elements retrieves the info from registry and
updates INSTALLDIR.

For golang/go#43681.