### PR TITLE
gerrit: add WebLinks field to ProjectInfo

### DIFF
--- a/gerrit/gerrit.go
+++ b/gerrit/gerrit.go
@@ -725,6 +725,7 @@ type ProjectInfo struct {
 	Description string            `json:"description"`
 	State       string            `json:"state"`
 	Branches    map[string]string `json:"branches"`
+	WebLinks    []WebLinkInfo     `json:"web_links,omitempty"`
 }
 
 // ListProjects returns the server's active projects.


### PR DESCRIPTION
Make its content available to callers, like already done in TagInfo.