### PR TITLE
dashboard: remove dragonfly-amd64-5_8 builder

### DIFF
--- a/dashboard/builders.go
+++ b/dashboard/builders.go
@@ -352,14 +352,6 @@ var Hosts = map[string]*HostConfig{
 		env:         []string{"GOROOT_BOOTSTRAP=/usr/pkg/go114"},
 		OwnerGithub: "bsiegert",
 	},
-	"host-dragonfly-amd64-5_8": &HostConfig{
-		IsReverse:   true,
-		ExpectNum:   1,
-		Notes:       "DragonFly BSD release version, run by DragonFly team",
-		env:         []string{"GOROOT_BOOTSTRAP=/usr/local/go"},
-		SSHUsername: "root",
-		OwnerGithub: "tuxillo",
-	},
 	"host-dragonfly-amd64-master": &HostConfig{
 		IsReverse:   true,
 		ExpectNum:   1,
@@ -2609,14 +2601,6 @@ func init() {
 		buildsRepo: func(repo, branch, goBranch string) bool {
 			return atLeastGo1(goBranch, 14) && buildRepoByDefault(repo)
 		},
-	})
-	addBuilder(BuildConfig{
-		Name:           "dragonfly-amd64-5_8",
-		HostType:       "host-dragonfly-amd64-5_8",
-		Notes:          "DragonFly BSD 5.8 release",
-		distTestAdjust: noTestDirAndNoReboot,
-		env:            []string{"GO_TEST_TIMEOUT_SCALE=2"}, // see golang.org/issue/45216
-		SkipSnapshot:   true,
 	})
 	addBuilder(BuildConfig{
 		Name:           "freebsd-arm-paulzhol",

--- a/dashboard/builders_test.go
+++ b/dashboard/builders_test.go
@@ -609,9 +609,6 @@ func TestBuilderConfig(t *testing.T) {
 		{b("dragonfly-amd64", "net"), onlyPost},
 		{b("dragonfly-amd64@go1.13", "net"), none}, // Dragonfly ABI changes only supported by Go 1.14+
 		{b("dragonfly-amd64@go1.13", "go"), none},  // Dragonfly ABI changes only supported by Go 1.14+
-		{b("dragonfly-amd64-5_8", "go"), onlyPost},
-		{b("dragonfly-amd64-5_8", "net"), onlyPost},
-		{b("dragonfly-amd64-5_8@go1.13", "net"), onlyPost},
 
 		{b("linux-amd64-staticlockranking", "go"), onlyPost},
 		{b("linux-amd64-staticlockranking@go1.15", "go"), onlyPost},


### PR DESCRIPTION
This builder is no longer needed since 6.0 is out already and DragonFly
BSD can only support current RELEASE and bleeding-edge (tip). This was
discussed in golang.org/issue/46351. For ongoing work to migrate the
DragonFly BSD builders to GCE, see golang.org/issue/23060.

Fixes golang/go#46351.