### PR TITLE
cmd/releaseschedule: add dark mode aware svg css

### DIFF
--- a/cmd/releaseschedule/main.go
+++ b/cmd/releaseschedule/main.go
@@ -23,6 +23,22 @@ func doMain() error {
 	defer f.Close()
 	canvas := svg.New(f)
 	canvas.Start(600, 400)
+	canvas.Style("text/css",
+		`text {
+	fill: black;
+}
+line, path {
+	stroke: black;
+	fill: none;
+}
+@media (prefers-color-scheme: dark) {
+	text {
+		fill: white;
+	}
+	line, path {
+		stroke: white;
+	}
+}`)
 	canvas.Translate(300, 200)
 	for i, month := range strings.Split("Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec", " ") {
 		angle := func(midx int) float64 {
@@ -33,7 +49,7 @@ func doMain() error {
 		// Draw a single black wedge of the calendar.
 		path := fmt.Sprintf("M 0,0 L %v,%v A 100,100 0 0 0 %v,%v L 0 0",
 			100*math.Sin(begin), 100*math.Cos(begin), 100*math.Sin(end), 100*math.Cos(end))
-		canvas.Path(path, "stroke: black; fill:none")
+		canvas.Path(path)
 
 		// Draw the text. Spin it around for readability in the second half.
 		canvas.RotateTranslate(50, 0, angle(i)*360/(2*math.Pi)+20)
@@ -99,7 +115,7 @@ func doMain() error {
 				canvas.Arc(int(x*arcRadius), int(y*arcRadius), int(arcRadius), int(arcRadius), 0, false, true, int(nx*arcRadius), int(ny*arcRadius), "stroke-width:10; fill:none; stroke: "+color)
 			}
 			// Draw the line from the inner edge of the arc.
-			canvas.Line(int(x*(arcRadius-5)), int(y*(arcRadius-5)), int(x*(arcRadius+lineLength)), int(y*(arcRadius+lineLength)), "stroke:black")
+			canvas.Line(int(x*(arcRadius-5)), int(y*(arcRadius-5)), int(x*(arcRadius+lineLength)), int(y*(arcRadius+lineLength)))
 			canvas.Text(int(x*(arcRadius+lineLength+textoff)), int(y*(arcRadius+lineLength+textoff)), relName+": "+m.name, "text-anchor: "+textAnchor)
 		}
 	}


### PR DESCRIPTION
The SVG image used on https://go.dev/s/release is mostly unreadable
if viewed in dark mode (set in OS, browser, or github settings) as
the black text/lines on dark background are too close in color.
It would be possible to set a background color on the svg, but I
think the better answer is CSS in the SVG which is @media aware of
prefers-color-scheme:dark to switch the colors from black to white.

Remove the explicit style on line/path and add css for text/line/path
which is black but in dark mode changes to white.

Updates golang/go#58820
Fixes golang/go#59275