### PR TITLE
x/build/cmd/coordinator: report invalid SlowBots in TRY comments

### DIFF
--- a/cmd/coordinator/coordinator.go
+++ b/cmd/coordinator/coordinator.go
@@ -1102,9 +1102,6 @@ func findTryWork() error {
 			continue
 		} else {
 			ts := newTrySet(work)
-			if ts == nil {
-				continue
-			}
 			ts.wantedAsOf = now
 			tries[key] = ts
 		}
@@ -1211,9 +1208,8 @@ func newTrySet(work *apipb.GerritTryWorkItem) *trySet {
 	}
 
 	if len(invalidSlowBots) > 0 {
-		log.Printf("WARNING: invalid slowbots: %s", strings.Join(invalidSlowBots, ", "))
+		log.Printf("WARNING: invalid slowbots in TRY comment: %s", strings.Join(invalidSlowBots, ", "))
 		ts.noteInvalidSlowBots(invalidSlowBots)
-		return nil
 	}
 
 	// Defensive check that the input is well-formed.
@@ -1763,9 +1759,7 @@ func (ts *trySet) noteBuildComplete(bs *buildStatus) {
 func (ts *trySet) noteInvalidSlowBots(invalidSlowBots []string) {
 	gerritClient := pool.NewGCEConfiguration().GerritClient()
 	if err := gerritClient.SetReview(context.Background(), ts.ChangeTriple(), ts.Commit, gerrit.ReviewInput{
-		Tag:     tryBotsTag("failed"),
 		Message: fmt.Sprintf("Note that the following SlowBot terms didn't match any existing builder name or slowbot alias: %s", strings.Join(invalidSlowBots, ", ")),
-		Labels:  map[string]int{"TryBot-Result": -1},
 	}); err != nil {
 		log.Printf("Error leaving Gerrit comment on %s: %v", ts.Commit[:8], err)
 	}

--- a/cmd/coordinator/coordinator_test.go
+++ b/cmd/coordinator/coordinator_test.go
@@ -337,7 +337,7 @@ func TestSlowBotsFromComments(t *testing.T) {
 			},
 		},
 	}
-	slowBots := slowBotsFromComments(work)
+	slowBots, _ := slowBotsFromComments(work)
 	var got []string
 	for _, bc := range slowBots {
 		got = append(got, bc.Name)
@@ -487,5 +487,31 @@ func TestListPatchSetThreads(t *testing.T) {
 	}
 	if mostRecentTryBotThread != "aaf7aa39_658707c2" {
 		t.Errorf("wrong most recent TryBot thread: got %s, want %s", mostRecentTryBotThread, "aaf7aa39_658707c2")
+	}
+}
+
+func TestInvalidSlowBots(t *testing.T) {
+	work := &apipb.GerritTryWorkItem{
+		Version: 2,
+		TryMessage: []*apipb.TryVoteMessage{
+			{
+				Version: 1,
+				Message: "aix, linux-mipps, amd64, freeebsd",
+			},
+		},
+	}
+	slowBots, invalidSlowBots := slowBotsFromComments(work)
+	var got []string
+	for _, bc := range slowBots {
+		got = append(got, bc.Name)
+	}
+	want := []string{"aix-ppc64", "linux-amd64"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("mismatch:\n got: %q\nwant: %q\n", got, want)
+	}
+
+	wantInvalid := []string{"linux-mipps", "freeebsd"}
+	if !reflect.DeepEqual(invalidSlowBots, wantInvalid) {
+		t.Errorf("mismatch:\n got: %q\nwant: %q\n", invalidSlowBots, wantInvalid)
 	}
 }

--- a/cmd/coordinator/coordinator_test.go
+++ b/cmd/coordinator/coordinator_test.go
@@ -337,7 +337,7 @@ func TestSlowBotsFromComments(t *testing.T) {
 			},
 		},
 	}
-	slowBots, _ := slowBotsFromComments(work)
+	slowBots, invalidSlowBots := slowBotsFromComments(work)
 	var got []string
 	for _, bc := range slowBots {
 		got = append(got, bc.Name)
@@ -345,6 +345,10 @@ func TestSlowBotsFromComments(t *testing.T) {
 	want := []string{"aix-ppc64", "darwin-amd64-13", "linux-arm64"}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("mismatch:\n got: %q\nwant: %q\n", got, want)
+	}
+
+	if len(invalidSlowBots) > 0 {
+		t.Errorf("mismatch invalidSlowBots:\n got: %d\nwant: 0", len(invalidSlowBots))
 	}
 }
 

--- a/cmd/coordinator/coordinator_test.go
+++ b/cmd/coordinator/coordinator_test.go
@@ -264,8 +264,8 @@ func TestIssue42084(t *testing.T) {
 
 	// Next, add try messages, and check that the SlowBot is now included.
 	work.TryMessage = []*apipb.TryVoteMessage{
-		{Message: "TRY=linux", AuthorId: 1234, Version: 1},
-		{Message: "TRY=linux-arm", AuthorId: 1234, Version: 1},
+		{Message: "linux", AuthorId: 1234, Version: 1},
+		{Message: "linux-arm", AuthorId: 1234, Version: 1},
 	}
 	ts = newTrySet(work)
 	hasLinuxArmBuilder = false


### PR DESCRIPTION
If an invalid SlowBot is requested alongside valid ones via the `TRY=`
comments only the valid builders run, while silently ignoring the
invalid ones.

This CL updates this behaviour to report any invalid builder terms via a
automated review comment.

Fixes golang/go#58902