### PR TITLE
dashboard: add OpenBSD 7.3 and 7.4 builders for 386, amd64

### DIFF
--- a/dashboard/builders.go
+++ b/dashboard/builders.go
@@ -502,6 +502,30 @@ var Hosts = map[string]*HostConfig{
 		Notes:       "OpenBSD 7.2; GCE VM, built from build/env/openbsd-amd64",
 		SSHUsername: "gopher",
 	},
+	"host-openbsd-386-73": {
+		VMImage:     "openbsd-386-73",
+		machineType: "n2", // force Intel; see go.dev/issue/49209
+		Notes:       "OpenBSD 7.3; GCE VM, built from build/env/openbsd-386",
+		SSHUsername: "gopher",
+	},
+	"host-openbsd-amd64-73": {
+		VMImage:     "openbsd-amd64-73",
+		machineType: "n2", // force Intel; see go.dev/issue/49209
+		Notes:       "OpenBSD 7.3; GCE VM, built from build/env/openbsd-amd64",
+		SSHUsername: "gopher",
+	},
+	"host-openbsd-386-74": {
+		VMImage:     "openbsd-386-74",
+		machineType: "n2", // force Intel; see go.dev/issue/49209
+		Notes:       "OpenBSD 7.4; GCE VM, built from build/env/openbsd-386",
+		SSHUsername: "gopher",
+	},
+	"host-openbsd-amd64-74": {
+		VMImage:     "openbsd-amd64-74",
+		machineType: "n2", // force Intel; see go.dev/issue/49209
+		Notes:       "OpenBSD 7.4; GCE VM, built from build/env/openbsd-amd64",
+		SSHUsername: "gopher",
+	},
 	"host-openbsd-arm-joelsing": {
 		IsReverse: true,
 		ExpectNum: 1,
@@ -2053,6 +2077,44 @@ func init() {
 	addBuilder(BuildConfig{
 		Name:     "openbsd-386-72",
 		HostType: "host-openbsd-386-72",
+		tryBot:   explicitTrySet("sys"),
+		buildsRepo: func(repo, branch, goBranch string) bool {
+			// https://go.dev/issue/49529: git seems to be too slow on this
+			// platform.
+			return repo != "review" && buildRepoByDefault(repo)
+		},
+		distTestAdjust:    noTestDirAndNoReboot,
+		numTryTestHelpers: 4,
+	})
+	addBuilder(BuildConfig{
+		Name:              "openbsd-amd64-73",
+		HostType:          "host-openbsd-amd64-73",
+		tryBot:            defaultTrySet(),
+		distTestAdjust:    noTestDirAndNoReboot,
+		numTryTestHelpers: 4,
+	})
+	addBuilder(BuildConfig{
+		Name:     "openbsd-386-73",
+		HostType: "host-openbsd-386-73",
+		tryBot:   explicitTrySet("sys"),
+		buildsRepo: func(repo, branch, goBranch string) bool {
+			// https://go.dev/issue/49529: git seems to be too slow on this
+			// platform.
+			return repo != "review" && buildRepoByDefault(repo)
+		},
+		distTestAdjust:    noTestDirAndNoReboot,
+		numTryTestHelpers: 4,
+	})
+	addBuilder(BuildConfig{
+		Name:              "openbsd-amd64-74",
+		HostType:          "host-openbsd-amd64-74",
+		tryBot:            defaultTrySet(),
+		distTestAdjust:    noTestDirAndNoReboot,
+		numTryTestHelpers: 4,
+	})
+	addBuilder(BuildConfig{
+		Name:     "openbsd-386-74",
+		HostType: "host-openbsd-386-74",
 		tryBot:   explicitTrySet("sys"),
 		buildsRepo: func(repo, branch, goBranch string) bool {
 			// https://go.dev/issue/49529: git seems to be too slow on this

--- a/env/openbsd-amd64/README
+++ b/env/openbsd-amd64/README
@@ -3,18 +3,18 @@ OpenBSD builder, booting up to run the buildlet.
 
 make.bash should be run on a Linux box with expect and qemu.
 Debian packages: expect qemu-utils qemu-system-x86 growisofs genisoimage.
-    VERSION=7.2 ARCH=amd64 ./make.bash
+    VERSION=7.4 ARCH=amd64 ./make.bash
 
 After it completes, it creates a file openbsd-${VERSION}-${ARCH}-gce.tar.gz
 
 Then:
-    gsutil cp -a public-read openbsd-7.2-amd64-gce.tar.gz gs://go-builder-data/openbsd-amd64-72.tar.gz
+    gsutil cp -a public-read openbsd-7.4-amd64-gce.tar.gz gs://go-builder-data/openbsd-amd64-74.tar.gz
 Or just use the web UI at:
     https://console.developers.google.com/project/symbolic-datum-552/storage/browser/go-builder-data/
 
 Then:
-    gcloud compute --project symbolic-datum-552 images delete openbsd-amd64-72
-    gcloud compute --project symbolic-datum-552 images create openbsd-amd64-72 --source-uri gs://go-builder-data/openbsd-amd64-72.tar.gz
+    gcloud compute --project symbolic-datum-552 images delete openbsd-amd64-74
+    gcloud compute --project symbolic-datum-552 images create openbsd-amd64-74 --source-uri gs://go-builder-data/openbsd-amd64-74.tar.gz
 
 The VM needs to be run with the GCE metadata attribute "buildlet-binary-url" set to a URL
 of the OpenBSD buildlet (cross-compiled, typically).

--- a/env/openbsd-amd64/make.bash
+++ b/env/openbsd-amd64/make.bash
@@ -7,7 +7,7 @@ set -e
 set -u
 
 # Update to the version listed on https://openbsd.org
-readonly VERSION="${VERSION:-7.2}"
+readonly VERSION="${VERSION:-7.4}"
 readonly RELNO="${VERSION/./}"
 readonly SNAPSHOT=false
 


### PR DESCRIPTION
With the release of OpenBSD 7.4 we need to update our builders
configuration to support the newer versions, since the latest builder
is version 7.2.

I did not update the default builders for openbsd, openbsd-386 and
openbsd-amd64 to prevent current builders from failing, since we
need the GCE VMs ready.

Fixes golang/go#63568