### PR TITLE
dashboard: fix env/dragonfly-amd64 build

### DIFF
--- a/env/dragonfly-amd64/phase2.sh
+++ b/env/dragonfly-amd64/phase2.sh
@@ -22,7 +22,17 @@ q' | ed /etc/rc.d/pfi
 # pfi startup does not have full path that a root login does.
 export PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/games:/usr/local/sbin:/usr/local/bin:/usr/pkg/sbin:/usr/pkg/bin:/root/bin
 
+# Upgrade pkg first
+pkg update
+pkg upgrade -y pkg || true
+
+# pkg 1.14 had a bug
+[ ! -f /usr/local/etc/pkg/repos/df-latest.conf ] && \
+    cp /usr/local/etc/pkg/repos/df-latest.conf.sample /usr/local/etc/pkg/repos/df-latest.conf
+
 # Update pkg database and install extras we need.
+pkg update
+pkg upgrade -fy
 pkg install -y bash curl git gdb
 
 echo 'DONE WITH PHASE 2.'


### PR DESCRIPTION
Due to several factors as an old pkg version in the ISO, or the amount
of changes that have gone to the binary packages since 6.4.0 was
released, a bit of a workaround is needed in phase2.sh

For golang/go#64684.