### PR TITLE
all: correct typos in comments and identifiers

### DIFF
--- a/dashboard/builders.go
+++ b/dashboard/builders.go
@@ -833,7 +833,7 @@ type BuildConfig struct {
 	// "std".
 	InstallRacePackages []string
 
-	// GoDeps is a list of of git sha1 commits that must be in the
+	// GoDeps is a list of git sha1 commits that must be in the
 	// commit to be tested's history. If absent, this builder is
 	// not run for that commit.
 	GoDeps []string

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -76,7 +76,7 @@ func Diff(oldName string, old []byte, newName string, new []byte) []byte {
 
 		// Expand matching lines as far possible,
 		// establishing that x[start.x:end.x] == y[start.y:end.y].
-		// Note that on the first (or last) iteration we may (or definitey do)
+		// Note that on the first (or last) iteration we may (or definitely do)
 		// have an empty match: start.x==end.x and start.y==end.y.
 		start := m
 		for start.x > done.x && start.y > done.y && x[start.x-1] == y[start.y-1] {

--- a/internal/gomote/gomote_test.go
+++ b/internal/gomote/gomote_test.go
@@ -1096,8 +1096,8 @@ func TestEmailToUser(t *testing.T) {
 		{"valid email", "george@funky.com", "george"},
 		{"single digit local", "g@funky.com", "g"},
 		{"single digit domain", "george@f", "george"},
-		{"colon", "example@gmail.com:more-info", "example"},                                 // while not desired, wont lead to a panic
-		{"multiple at", "example@gmail.com:example@gmail.com", "example@gmail.com:example"}, // while not desired, wont lead to a panic
+		{"colon", "example@gmail.com:more-info", "example"},                                 // while not desired, won't lead to a panic
+		{"multiple at", "example@gmail.com:example@gmail.com", "example@gmail.com:example"}, // while not desired, won't lead to a panic
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/internal/relui/workflows.go
+++ b/internal/relui/workflows.go
@@ -1028,7 +1028,7 @@ mv go/pkg/distpack/*.src.tar.gz src.tar.gz
 // any mismatch.
 //
 // As a special case, mismatches in the content of the VERSION file at the root are ignored.
-// TODO(go.dev/issue/62481): Make it detect a mismatch in the the VERSION file at the root, too.
+// TODO(go.dev/issue/62481): Make it detect a mismatch in the VERSION file at the root, too.
 func (b *BuildReleaseTasks) checkSourceMatch(ctx *wf.TaskContext, branch, versionFile string, source artifact) (head string, _ error) {
 	head, err := b.GerritClient.ReadBranchHead(ctx, b.GerritProject, branch)
 	if err != nil {

--- a/internal/task/tagx.go
+++ b/internal/task/tagx.go
@@ -638,12 +638,12 @@ func (x *TagXReposTasks) findMissingBuilders(ctx *wf.TaskContext, repo TagRepo, 
 			},
 			Status: buildbucketpb.Status_SUCCESS,
 		}
-		succesfulBuilds, err := x.BuildBucket.SearchBuilds(ctx, pred)
+		successfulBuilds, err := x.BuildBucket.SearchBuilds(ctx, pred)
 		if err != nil {
 			return nil, err
 		}
-		if len(succesfulBuilds) != 0 {
-			ctx.Printf("%v: found successful builds: %v", name, succesfulBuilds)
+		if len(successfulBuilds) != 0 {
+			ctx.Printf("%v: found successful builds: %v", name, successfulBuilds)
 			delete(wantBuilders, name)
 		} else {
 			ctx.Printf("%v: no successful builds", name)

--- a/update-readmes.go
+++ b/update-readmes.go
@@ -55,7 +55,7 @@ func main() {
 			return nil
 		}
 		if _, err := os.Stat(filepath.Join(pkg.Dir, "README")); err == nil {
-			// Directory has exiting README; don't touch.
+			// Directory has existing README; don't touch.
 			return nil
 		}
 		readmePath := filepath.Join(pkg.Dir, "README.md")


### PR DESCRIPTION
Fix a handful of typos found across comments and variable names

- Remove duplicate words ("the the", "of of") in two comment blocks
- Correct misspellings: "definitey" → "definitely", "exiting" → "existing"
- Fix variable name: "succesfulBuilds" → "successfulBuilds"
- Add missing apostrophe: "wont" → "won't" in test comment